### PR TITLE
Fix problem with nested RDD operations that causes negative durations

### DIFF
--- a/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/DurationFormatting.scala
+++ b/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/DurationFormatting.scala
@@ -51,10 +51,13 @@ object DurationFormatting {
 
   def formatDuration(duration: Duration): String = {
 
+    val builder = new StringBuilder()
+
     var nanoDuration = duration.toNanos
 
     if (nanoDuration < 0) {
-      throw new IllegalArgumentException("Duration must be greater or equal to zero!")
+      builder.append("-")
+      nanoDuration = Math.abs(nanoDuration)
     }
 
     val hours = TimeUnit.NANOSECONDS.toHours(nanoDuration)
@@ -74,7 +77,6 @@ object DurationFormatting {
 
     val nanos = nanoDuration
 
-    val builder = new StringBuilder()
     if (hours > 0) {
       builder.append(hours)
       builder.append(" hour").append(if (hours != 1) "s" else "")

--- a/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/DurationFormattingSuite.scala
+++ b/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/DurationFormattingSuite.scala
@@ -95,6 +95,12 @@ class DurationFormattingSuite extends FunSuite {
     assert(format(NANOSECONDS.toNanos(1)) === "1 ns")
   }
 
+  test("Negative duration does not throw an error") {
+    // If we get a negative duration we prefer to render it (even though it doesn't make sense)
+    // rather than throwing an error
+    assert(format(SECONDS.toNanos(-25)) === "-25 secs")
+  }
+
   def format(durationNanos: Long): String = {
     formatDuration(Duration.fromNanos(durationNanos))
   }

--- a/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/InstrumentedOrderedRDDFunctionsSuite.scala
+++ b/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/InstrumentedOrderedRDDFunctionsSuite.scala
@@ -1,0 +1,59 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.instrumentation
+
+import org.apache.spark.rdd.MetricsContext._
+import org.bdgenomics.utils.misc.SparkFunSuite
+
+import scala.collection.JavaConversions._
+
+class InstrumentedOrderedRDDFunctionsSuite extends SparkFunSuite {
+
+  sparkBefore("Before") {
+    Metrics.initialize(sc)
+  }
+
+  sparkAfter("After") {
+    Metrics.stopRecording()
+  }
+
+  sparkTest("Nested timings are not recorded for sortByKey operation") {
+
+    val rdd = sc.parallelize(Seq(1, 2, 3, 4, 5), 2).instrument().keyBy(e => e).sortByKey()
+    assert(rdd.count() === 5)
+
+    Metrics.Recorder.value.foreach(recorder => {
+      val timerMap = recorder.accumulable.value.timerMap
+      // We should have timings for 4 timers: keyBy, keyBy's function call, sortByKey, and count,
+      // but not for any nested operations within sortByKey
+      val timerNames = timerMap.keys().map(_.timerName).toSet
+      assert(timerNames.size === 4)
+      assertContains(timerNames, "keyBy")
+      assertContains(timerNames, "sortByKey")
+      assertContains(timerNames, "function call")
+      assertContains(timerNames, "count")
+    })
+
+  }
+
+  private def assertContains(names: Set[String], nameStartsWith: String) = {
+    assert(names.count(_.startsWith(nameStartsWith)) === 1,
+      "Timer names [" + names + "] did not contain [" + nameStartsWith + "]")
+  }
+
+}


### PR DESCRIPTION
This fixes a problem with certain Spark RDD operations, like sortByKey, that themselves call other RDD operations. This was leading to miscalculation of timings, and negative durations (which threw errors).

The fix is to ignore nested RDD operations. So if Spark internally calls RDD operations these are not instrumented.

I have also changed DurationFormatting to avoid throwing an error on negative durations. I think it's better just to print the negative duration than throw an error, as an error causes no stats to be printed and makes tracking down the cause of the negative duration more difficult.