### PR TITLE
kill `job` argument to BDGSparkCommand

### DIFF
--- a/utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
+++ b/utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
@@ -18,10 +18,8 @@
 package org.bdgenomics.utils.cli
 
 import java.io.{ StringWriter, PrintWriter }
-import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ SparkConf, Logging, SparkContext }
 import org.bdgenomics.utils.instrumentation._
-import org.bdgenomics.utils.misc.HadoopUtil
 
 trait BDGCommandCompanion {
   val commandName: String
@@ -42,7 +40,7 @@ trait BDGCommand extends Runnable {
 trait BDGSparkCommand[A <: Args4jBase] extends BDGCommand with Logging {
   protected val args: A
 
-  def run(sc: SparkContext, job: Job)
+  def run(sc: SparkContext)
 
   def run() {
     val start = System.nanoTime()
@@ -51,9 +49,8 @@ trait BDGSparkCommand[A <: Args4jBase] extends BDGCommand with Logging {
       conf.setMaster("local[%d]".format(Runtime.getRuntime.availableProcessors()))
     }
     val sc = new SparkContext(conf)
-    val job = HadoopUtil.newJob()
     val metricsListener = initializeMetrics(sc)
-    run(sc, job)
+    run(sc)
     val totalTime = System.nanoTime() - start
     printMetrics(totalTime, metricsListener)
   }


### PR DESCRIPTION
fixes #37 

I think this should be merge-able whenever, though the corresponding version-bump in ADAM will have to go along with the corresponding refactor over there, which I have locally built off of [ADAM#664](https://github.com/bigdatagenomics/adam/pull/664) and will file shortly, for merging whenever we're ready to actually do that upgrade, or cut a branch that includes backwards-incompatible changes from `bdg-utils-0.2.1`