### PR TITLE
[utils-42] Upgrading to the org.apache.parquet release of Parquet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <java.version>1.7</java.version>
     <spark.version>1.2.0</spark.version>
-    <parquet.version>1.6.0rc4</parquet.version>
+    <parquet.version>1.7.0</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
@@ -383,7 +383,7 @@
         <version>0.10</version>
       </dependency>
       <dependency>
-        <groupId>com.twitter</groupId>
+        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
         <version>${parquet.version}</version>
       </dependency>

--- a/utils-cli/pom.xml
+++ b/utils-cli/pom.xml
@@ -57,7 +57,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.twitter</groupId>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
     </dependency>
     <dependency>

--- a/utils-cli/src/main/scala/org/bdgenomics/utils/cli/ParquetArgs.scala
+++ b/utils-cli/src/main/scala/org/bdgenomics/utils/cli/ParquetArgs.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.utils.cli
 
 import org.kohsuke.args4j.{ Argument, Option }
-import parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
 
 trait ParquetRDDArgs {
   var blockSize: Int

--- a/utils-io/pom.xml
+++ b/utils-io/pom.xml
@@ -27,7 +27,7 @@
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
-          <filereports>BDGUtilsParquetTestSuite.txt</filereports>
+          <filereports>BDGUtilsIOTestSuite.txt</filereports>
           <!--
               As explained here: http://stackoverflow.com/questions/1660441/java-flag-to-enable-extended-serialization-debugging-info
               The second option allows us better debugging for serialization-based errors.
@@ -141,10 +141,6 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.10</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.twitter</groupId>
-      <artifactId>parquet-avro</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Necessary for https://github.com/bigdatagenomics/adam/issues/716.