### PR TITLE
[utils-46] removing duplicate declaration of spark-core dependency

### DIFF
--- a/utils-serialization/pom.xml
+++ b/utils-serialization/pom.xml
@@ -127,11 +127,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.10</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Fixes #46 