### PR TITLE
Remove help processing shortcut

### DIFF
--- a/utils-cli/src/main/scala/org/bdgenomics/utils/cli/Args4j.scala
+++ b/utils-cli/src/main/scala/org/bdgenomics/utils/cli/Args4j.scala
@@ -40,20 +40,20 @@ object Args4j {
       System.exit(exitCode)
     }
 
-    // Work around for help processing in Args4j
-    if (args.exists(helpOptions.contains(_))) {
-      displayHelp()
-    }
-
     try {
       parser.parseArgument(args.toList)
-      if (args4j.doPrintUsage)
+      if (!ignoreCmdLineExceptions && args4j.doPrintUsage) {
         displayHelp()
+      }
     } catch {
       case e: CmdLineException =>
         if (!ignoreCmdLineExceptions) {
-          println(e.getMessage)
-          displayHelp(1)
+          if (args4j.doPrintUsage) {
+            displayHelp()
+          } else {
+            println(e.getMessage)
+            displayHelp(1)
+          }
         }
     }
 


### PR DESCRIPTION
Possible fix for https://github.com/bigdatagenomics/adam/issues/755

These cover the changed lines of code completely
```bash
$ ./bin/adam-submit
15/08/17 17:56:13 INFO ADAMMain: ADAM invoked with args: 

     e            888~-_              e                 e    e
    d8b           888   \            d8b               d8b  d8b
   /Y88b          888    |          /Y88b             d888bdY88b
  /  Y88b         888    |         /  Y88b           / Y88Y Y888b
 /____Y88b        888   /         /____Y88b         /   YY   Y888b
/      Y88b       888_-~         /      Y88b       /          Y888b

Usage: adam-submit [<spark-args> --] <adam-args>
...

$ ./bin/adam-submit -h
15/08/17 17:56:15 INFO ADAMMain: ADAM invoked with args: "-h"

     e            888~-_              e                 e    e
    d8b           888   \            d8b               d8b  d8b
   /Y88b          888    |          /Y88b             d888bdY88b
  /  Y88b         888    |         /  Y88b           / Y88Y Y888b
 /____Y88b        888   /         /____Y88b         /   YY   Y888b
/      Y88b       888_-~         /      Y88b       /          Y888b

Usage: adam-submit [<spark-args> --] <adam-args>
...

$ ./bin/adam-submit depth 
15/08/17 17:57:52 INFO ADAMMain: ADAM invoked with args: "depth"
Argument "ADAM" is required
 ADAM                                                            : The Read file to use to calculate depths
 VCF                                                             : The VCF containing the sites at which to calculate depths
 -cartesian                                                      : Use a cartesian join, then filter
 -h (-help, --help, -?)                                          : Print help
 -parquet_block_size N                                           : Parquet block size (default = 128mb)
 -parquet_compression_codec [UNCOMPRESSED | SNAPPY | GZIP | LZO] : Parquet compression codec
 -parquet_disable_dictionary                                     : Disable dictionary encoding
 -parquet_logging_level VAL                                      : Parquet logging level (default = severe)
 -parquet_page_size N                                            : Parquet page size (default = 1mb)
 -print_metrics                                                  : Print metrics to the log on completion

$ ./bin/adam-submit depth -h
15/08/17 17:57:55 INFO ADAMMain: ADAM invoked with args: "depth" "-h"
 ADAM                                                            : The Read file to use to calculate depths
 VCF                                                             : The VCF containing the sites at which to calculate depths
 -cartesian                                                      : Use a cartesian join, then filter
 -h (-help, --help, -?)                                          : Print help
 -parquet_block_size N                                           : Parquet block size (default = 128mb)
 -parquet_compression_codec [UNCOMPRESSED | SNAPPY | GZIP | LZO] : Parquet compression codec
 -parquet_disable_dictionary                                     : Disable dictionary encoding
 -parquet_logging_level VAL                                      : Parquet logging level (default = severe)
 -parquet_page_size N                                            : Parquet page size (default = 1mb)
 -print_metrics                                                  : Print metrics to the log on completion

$ ./bin/adam-submit depth -cartesian -h
15/08/17 17:58:01 INFO ADAMMain: ADAM invoked with args: "depth" "-cartesian" "-h"
 ADAM                                                            : The Read file to use to calculate depths
 VCF                                                             : The VCF containing the sites at which to calculate depths
 -cartesian                                                      : Use a cartesian join, then filter
 -h (-help, --help, -?)                                          : Print help
 -parquet_block_size N                                           : Parquet block size (default = 128mb)
 -parquet_compression_codec [UNCOMPRESSED | SNAPPY | GZIP | LZO] : Parquet compression codec
 -parquet_disable_dictionary                                     : Disable dictionary encoding
 -parquet_logging_level VAL                                      : Parquet logging level (default = severe)
 -parquet_page_size N                                            : Parquet page size (default = 1mb)
 -print_metrics                                                  : Print metrics to the log on completion

$ ./bin/adam-submit wigfix2bed -h
15/08/17 17:58:19 INFO ADAMMain: ADAM invoked with args: "wigfix2bed" "-h"
 -bed VAL               : Location to write BED data (leave out for stdout)
 -h (-help, --help, -?) : Print help
 -print_metrics         : Print metrics to the log on completion
 -wig VAL               : The wig file to convert (leave out for stdin)
```

I'm not a fan of ```ignoreCmdLineExceptions``` nor of boolean flags generally; please feel free to make other suggestions.