### PR TITLE
[utils-55] Disregards significant outliers during EM stage.

### DIFF
--- a/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/mixtures/DiscreteKMeansMixtureModel.scala
+++ b/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/mixtures/DiscreteKMeansMixtureModel.scala
@@ -57,6 +57,9 @@ trait DiscreteKMeansMixtureModel[D <: DiscreteDistr[Int]]
       .reduce(_ + _)
 
     // return soft assignment and ECLL contribution
+    if (weight <= 0.0) {
+      log.warn("Value %d had zero probabilities under all distributions and was dropped.".format(value))
+    }
     (membership, pointEcll)
   }
 


### PR DESCRIPTION
During the EM fit, if you have a point that is a very distant outlier, this
point can have a 0.0 probability of being generated from each mixture component.
When we softmax the weight vector, this leads to the softmax vector being full
of NaNs, which then leads to trouble when aggregating during the M step. To fix
this, we check for a vector of NaNs when aggregating. If there is a NaN vector,
we treat the vector as a NOP --> zero vector. This resolves a downstream issue
where we were fitting a Poisson mixture to k-mer counts where one highly
repetitive k-mer had a count value that was 100x higher than the highest
Poisson mean in our mixture. Resolves #55.