### PR TITLE
Remove dependency on Spark internal Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.7</java.version>
-    <spark.version>1.5.2</spark.version>
+    <spark.version>1.6.1</spark.version>
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>

--- a/utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
+++ b/utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
@@ -18,7 +18,8 @@
 package org.bdgenomics.utils.cli
 
 import java.io.{ StringWriter, PrintWriter }
-import org.apache.spark.{ SparkConf, Logging, SparkContext }
+import org.apache.spark.{ SparkConf, SparkContext }
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.utils.instrumentation._
 
 trait BDGCommandCompanion {

--- a/utils-io/src/main/scala/org/bdgenomics/utils/io/HTTPRangedByteAccess.scala
+++ b/utils-io/src/main/scala/org/bdgenomics/utils/io/HTTPRangedByteAccess.scala
@@ -23,7 +23,7 @@ import java.net.URI
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.{ HttpGet, HttpHead }
 import org.apache.http.impl.client.{ HttpClients, StandardHttpRequestRetryHandler }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 
 /**
  * HTTPRangedByteAccess supports Ranged GET queries against HTTP resources.

--- a/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/MetricsSuite.scala
+++ b/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/MetricsSuite.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.utils.instrumentation
 
 import java.io.{ PrintWriter, StringWriter, BufferedReader, StringReader }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.Timer
 import org.bdgenomics.utils.instrumentation.InstrumentationTestingUtil._
 import org.bdgenomics.utils.misc.SparkFunSuite

--- a/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/SparkMetricsSuite.scala
+++ b/utils-metrics/src/test/scala/org/bdgenomics/utils/instrumentation/SparkMetricsSuite.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.utils.instrumentation
 
 import java.io._
 import java.util.concurrent.TimeUnit
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.utils.instrumentation.InstrumentationTestingUtil._
 import org.scalatest.FunSuite
 import scala.concurrent.duration._

--- a/utils-misc/src/main/scala/org/bdgenomics/utils/misc/Logging.scala
+++ b/utils-misc/src/main/scala/org/bdgenomics/utils/misc/Logging.scala
@@ -1,0 +1,133 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.misc
+
+import org.slf4j.{ Logger, LoggerFactory }
+
+trait Logging {
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on anotlsher machine
+  @transient private var log_ : Logger = null
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) {
+      initializeIfNecessary()
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+  protected def isTraceEnabled(): Boolean = {
+    log.isTraceEnabled
+  }
+
+  private def initializeIfNecessary() {
+    if (!Logging.initialized) {
+      Logging.initLock.synchronized {
+        if (!Logging.initialized) {
+          initializeLogging()
+        }
+      }
+    }
+  }
+
+  private def initializeLogging() {
+
+    Logging.initialized = true
+
+    // Force a call into slf4j to initialize it. Avoids this happening from multiple threads
+    // and triggering this: http://mailman.qos.ch/pipermail/slf4j-dev/2010-April/002956.html
+    log
+  }
+}
+
+private object Logging {
+
+  def getClassLoader: ClassLoader = getClass.getClassLoader
+
+  def getContextOrClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getClassLoader)
+
+  def classForName(className: String): Class[_] = {
+    Class.forName(className, true, getContextOrClassLoader)
+  }
+
+  @volatile private var initialized = false
+  val initLock = new Object()
+  try {
+    // We use reflection here to handle the case where users remove the
+    // slf4j-to-jul bridge order to route their logs to JUL.
+    val bridgeClass = classForName("org.slf4j.bridge.SLF4JBridgeHandler")
+    bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
+    val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]
+    if (!installed) {
+      bridgeClass.getMethod("install").invoke(null)
+    }
+  } catch {
+    case e: ClassNotFoundException => // can't log anything yet so just fail silently
+  }
+}

--- a/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/mixtures/DiscreteMixtureModel.scala
+++ b/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/mixtures/DiscreteMixtureModel.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.utils.statistics.mixtures
 
 import breeze.stats.distributions.DiscreteDistr
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
 

--- a/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/normalization/ZScoreNormalization.scala
+++ b/utils-statistics/src/main/scala/org/bdgenomics/utils/statistics/normalization/ZScoreNormalization.scala
@@ -17,7 +17,7 @@
  */
 package org.bdgenomics.utils.statistics.normalization
 
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import scala.math.sqrt
 


### PR DESCRIPTION
Recent versions of Spark make Logging private, breaking logging code in ADAM and potentially other bdg projects.  This PR removes the dependency on `org.apache.spark.Logging` for projects using bdg-utils.

Note - Spark version is also bumped to 1.6.1 below, but this PR should work with Spark 1.5 as well