### PR TITLE
Fix artifact naming issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bdgenomics.utils</groupId>
-  <artifactId>utils-parent-spark2_2.10</artifactId>
+  <artifactId>utils-parent_2.10</artifactId>
   <version>0.2.9-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>utils</name>
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.7</java.version>
-    <spark.version>2.0.0</spark.version>
+    <spark.version>1.6.1</spark.version>
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>
@@ -82,7 +82,7 @@
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
             <arguments>-Psonatype-oss-release</arguments>
-            <tagNameFormat>utils-parent-spark2_2.10-${project.version}</tagNameFormat>
+            <tagNameFormat>utils-parent_2.10-${project.version}</tagNameFormat>
           </configuration>
         </plugin>
         <plugin>
@@ -280,24 +280,24 @@
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-misc-spark2_2.10</artifactId>
+        <artifactId>utils-misc_2.10</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-misc-spark2_2.10</artifactId>
+        <artifactId>utils-misc_2.10</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-io-spark2_2.10</artifactId>
+        <artifactId>utils-io_2.10</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-metrics-spark2_2.10</artifactId>
+        <artifactId>utils-metrics_2.10</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,14 +1,105 @@
 #!/bin/sh
 
+# do we have enough arguments?
+if [ $# < 3 ]; then
+    echo "Usage:"
+    echo
+    echo "./release.sh <release version> <development version>"
+    exit 1
+fi
+
+# pick arguments
+release=$1
+devel=$2
+
+# get current branch
+branch=$(git status -bs | awk '{ print $2 }' | awk -F'.' '{ print $1 }' | head -n 1)
+
+commit=$(git log --pretty=format:"%H" | head -n 1)
+echo "releasing from ${commit} on branch ${branch}"
+
+git push origin ${branch}
+
 # do scala 2.10 release
-mvn -Dresume=false release:clean release:prepare release:perform
+git checkout -b maint_2.10-${release} ${branch}
+mvn --batch-mode \
+  -Dresume=false \
+  -Dtag=utils-parent_2.10-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=utils_2.10-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing Spark 1, Scala 2.10 version failed."
+  exit 1
+fi
 
 # do scala 2.11 release
+git checkout -b maint_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
-git commit -a -m "Modifying pom.xml files for 2.11 release."
-mvn -Dresume=false release:clean release:prepare release:perform
+git commit -a -m "Modifying pom.xml files for Spark 1, Scala 2.11 release."
+mvn --batch-mode \
+  -Dresume=false \
+  -Dtag=utils-parent_2.11-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=utils_2.11-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
 
-# move back to 2.10 for development
-./scripts/move_to_scala_2.10.sh
-./scripts/changelog.sh | tee CHANGES.md
-git commit -a -m "Modifying pom.xml files to move back to Scala 2.10 for development."
+if [ $? != 0 ]; then
+  echo "Releasing Spark 1, Scala 2.11 version failed."
+  exit 1
+fi
+
+# do spark 2, scala 2.10 release
+git checkout -b maint_spark2_2.10-${release} ${branch}
+./scripts/move_to_spark_2.sh
+git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.10 release."
+mvn --batch-mode \
+  -Dresume=false \
+  -Dtag=utils-parent-spark2_2.10-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=utils-spark2_2.10-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing Spark 2, Scala 2.10 version failed."
+  exit 1
+fi
+
+# do spark 2, scala 2.11 release
+git checkout -b maint_spark2_2.11-${release} ${branch}
+./scripts/move_to_spark_2.sh
+./scripts/move_to_scala_2.11.sh
+git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.11 release."
+mvn --batch-mode \
+  -Dresume=false \
+  -Dtag=utils-parent-spark2_2.11-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=utils-spark2_2.11-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing Spark 2, Scala 2.11 version failed."
+  exit 1
+fi
+
+if [ $branch = "master" ]; then
+  # if original branch was master, update versions on original branch
+  git checkout ${branch}
+  mvn versions:set -DnewVersion=${devel} \
+    -DgenerateBackupPoms=false
+  git commit -a -m "Modifying pom.xml files for new development after ${release} release."
+  git push origin ${branch}
+fi

--- a/utils-cli/pom.xml
+++ b/utils-cli/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>utils-cli-spark2_2.10</artifactId>
+  <artifactId>utils-cli_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-cli-spark2_2.10: utilities for building command line applications</name>
+  <name>utils-cli_2.10: utilities for building command line applications</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -70,11 +70,11 @@
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-metrics-spark2_2.10</artifactId>
+      <artifactId>utils-metrics_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/utils-intervalrdd/pom.xml
+++ b/utils-intervalrdd/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-intervalrdd-spark2_2.10</artifactId>
+  <artifactId>utils-intervalrdd_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-intervalrdd-spark2_2.10: IntervalRDD based on interval tree</name>
+  <name>utils-intervalrdd_2.10: IntervalRDD based on interval tree</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -89,13 +89,13 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
   <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
   </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/utils-io/pom.xml
+++ b/utils-io/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-io-spark2_2.10</artifactId>
+  <artifactId>utils-io_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-io-spark2_2.10: I/O utils</name>
+  <name>utils-io_2.10: I/O utils</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -90,17 +90,17 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-metrics-spark2_2.10</artifactId>
+      <artifactId>utils-metrics_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/utils-metrics/pom.xml
+++ b/utils-metrics/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-metrics-spark2_2.10</artifactId>
+  <artifactId>utils-metrics_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-metrics-spark2_2.10: tools for collecting metrics on top of RDDs</name>
+  <name>utils-metrics_2.10: tools for collecting metrics on top of RDDs</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -90,13 +90,13 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>com.netflix.servo</groupId>

--- a/utils-minhash/pom.xml
+++ b/utils-minhash/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-minhash-spark2_2.10</artifactId>
+  <artifactId>utils-minhash_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-minhash-spark2_2.10: MinHash-based Jaccard similarity estimator</name>
+  <name>utils-minhash_2.10: MinHash-based Jaccard similarity estimator</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -90,13 +90,13 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/utils-misc/pom.xml
+++ b/utils-misc/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-misc-spark2_2.10</artifactId>
+  <artifactId>utils-misc_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-misc-spark2_2.10: Miscellaneous Spark helper code</name>
+  <name>utils-misc_2.10: Miscellaneous Spark helper code</name>
   <build>
     <plugins>
       <!-- disable surefire -->

--- a/utils-serialization/pom.xml
+++ b/utils-serialization/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-serialization-spark2_2.10</artifactId>
+  <artifactId>utils-serialization_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-serialization-spark2_2.10: tools for serializing data</name>
+  <name>utils-serialization_2.10: tools for serializing data</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -90,7 +90,7 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>

--- a/utils-statistics/pom.xml
+++ b/utils-statistics/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.utils</groupId>
-    <artifactId>utils-parent-spark2_2.10</artifactId>
+    <artifactId>utils-parent_2.10</artifactId>
     <version>0.2.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>utils-statistics-spark2_2.10</artifactId>
+  <artifactId>utils-statistics_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>utils-statistics-spark2_2.10: Spark code for fitting statistical models</name>
+  <name>utils-statistics_2.10: Spark code for fitting statistical models</name>
   <build>
     <plugins>
       <!-- disable surefire -->
@@ -98,13 +98,13 @@
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.10</artifactId>
+      <artifactId>utils-misc_2.10</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Reverts the commit that changed to the Spark 2 naming convention on the master branch. Moves to the ADAM release scripts for future releases, which branch then release.