### PR TITLE
Close InputStream opened in readByteStream

### DIFF
--- a/utils-io/src/main/scala/org/bdgenomics/utils/io/ByteAccess.scala
+++ b/utils-io/src/main/scala/org/bdgenomics/utils/io/ByteAccess.scala
@@ -41,10 +41,14 @@ trait ByteAccess {
     var totalBytesRead: Int = 0
     val buffer = new Array[Byte](length)
     val is = readByteStream(offset, length)
-    while (totalBytesRead < length) {
-      val bytesRead = is.read(buffer, totalBytesRead, length - totalBytesRead)
-      totalBytesRead += bytesRead
+    try {
+      while (totalBytesRead < length) {
+        val bytesRead = is.read(buffer, totalBytesRead, length - totalBytesRead)
+        totalBytesRead += bytesRead
+      }
+      buffer
+    } finally {
+      is.close()
     }
-    buffer
   }
 }


### PR DESCRIPTION
Closes the `InputStream` previously opened in `readByteStream`

Related to https://github.com/bigdatagenomics/adam/issues/1719