### PR TITLE
[UTILS-124] Add support for Scala 2.12.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <java.version>1.8</java.version>
     <scala.version>2.11.12</scala.version>
-    <spark.version>2.3.2</spark.version>
+    <spark.version>2.4.0</spark.version>
     <parquet.version>1.8.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.5</hadoop.version>
@@ -304,7 +304,7 @@
       <dependency>
         <groupId>com.netflix.servo</groupId>
         <artifactId>servo-core</artifactId>
-        <version>0.12.12</version>
+        <version>0.12.25</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,11 @@
         <version>2.24.0</version>
       </dependency>
       <dependency>
+        <groupId>com.thoughtworks.paranamer</groupId>
+        <artifactId>paranamer</artifactId>
+        <version>2.8</version>
+      </dependency>
+      <dependency>
         <groupId>org.bdgenomics.utils</groupId>
         <artifactId>utils-misc-spark2_2.11</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,6 @@
           <useZincServer>true</useZincServer>
           <args>
             <arg>-unchecked</arg>
-            <arg>-optimise</arg>
             <arg>-deprecation</arg>
           </args>
           <jvmArgs>

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -24,7 +24,6 @@ if ! [[ ${HADOOP_VERSION} ]];
 then
     echo "HADOOP_VERSION environment variable is not set."
     echo "Please set this variable before running."
-    
     exit 1
 fi
 
@@ -33,12 +32,37 @@ if ! [[ ${SPARK_VERSION} ]];
 then
     echo "SPARK_VERSION environment variable is not set."
     echo "Please set this variable before running."
-    
     exit 1
 fi
 
+# is the scala version set?
+if ! [[ ${SCALA_VERSION} ]];
+then
+    echo "SCALA_VERSION environment variable is not set."
+    echo "Please set this variable before running."
+    exit 1
+fi
+
+if [ ${SCALA_VERSION} == 2.11 ];
+then
+    # shouldn't be able to move to scala 2.11 twice
+    set +e
+    ./scripts/move_to_scala_2.11.sh
+    if [[ $? == 0 ]];
+    then
+        echo "We have already moved to Scala 2.11, so running move_to_scala_2.11.sh a second time should fail, but error code was 0 (success)."
+        exit 1
+    fi
+    set -e
+fi
+
+if [ ${SCALA_VERSION} == 2.12 ];
+then
+    ./scripts/move_to_scala_2.12.sh
+fi
+
 # print versions
-echo "Testing UTILS version ${VERSION} on Spark ${SPARK_VERSION} and Hadoop ${HADOOP_VERSION}"
+echo "Testing UTILS version ${VERSION} on Spark ${SPARK_VERSION} and Hadoop ${HADOOP_VERSION} and Scala ${SCALA_VERSION}"
 
 # if this is a pull request, we need to set the coveralls pr id
 if [[ ! -z $ghprbPullId ]];
@@ -70,24 +94,6 @@ set -x -v
 # we are done with maven, so clean up the maven temp dir
 find ${UTILS_MVN_TMP_DIR}
 rm -rf ${UTILS_MVN_TMP_DIR}
-
-# run integration tests on scala 2.10; prebuilt spark distributions are not available for 2.11
-if [ ${SCALAVER} == 2.10 ];
-then
-
-    # test that the source is formatted correctly
-    # we had modified the poms to add a temp dir, so check those out first
-    pushd ${PROJECT_ROOT}
-    find . -name pom.xml -exec git checkout {} \;
-    ./scripts/format-source
-    if test -n "$(git status --porcelain)"
-    then
-        echo "Please run './scripts/format-source'"
-        exit 1
-    fi
-    popd
-    
-fi
 
 echo
 echo "All the tests passed"

--- a/scripts/move_to_scala_2.10.sh
+++ b/scripts/move_to_scala_2.10.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set +x
-
-find . -name "pom.xml" -exec sed -e "s/2.11.8/2.10.6/g" -e "s/2.11/2.10/g" -i .2.10.bak '{}' \;
-find . -name "*.2.10.bak" -exec rm {} \;

--- a/scripts/move_to_scala_2.11.sh
+++ b/scripts/move_to_scala_2.11.sh
@@ -2,7 +2,16 @@
 
 set +x
 
-find . -name "pom.xml" -exec sed -e "s/2.10.6/2.11.8/g" -e "s/2.10/2.11/g" -i .2.11.bak '{}' \;
-# keep maven-javadoc-plugin at version 2.10.4
-find . -name "pom.xml" -exec sed -e "s/2.11.4/2.10.4/g" -i.2.11.2.bak '{}' \;
-find . -name "*.2.11.*bak" -exec rm {} \;
+grep "<scala\.version>" pom.xml | grep -q 2.11
+if [[ $? == 0 ]];
+then
+    echo "Scala version is already set to 2.11 (Scala artifacts have _2.11 version suffix in artifact name)."
+    echo "Cowardly refusing to move to Scala 2.11 a second time..."
+
+    exit 1
+fi
+
+find . -name "pom.xml" -exec sed -e "s/2.12.6/2.11.12/g" \
+    -e "s/2.12/2.11/g" \
+    -i.2.11.bak '{}' \;
+find . -name "*.2.11.*bak" -exec rm -f {} \;

--- a/scripts/move_to_scala_2.12.sh
+++ b/scripts/move_to_scala_2.12.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set +x
+grep "<scala\.version>" pom.xml | grep -q 2.12
+if [[ $? == 0 ]];
+then
+    echo "Scala version is already set to 2.12 (Scala artifacts have _2.12 version suffix in artifact name)."
+    echo "Cowardly refusing to move to Scala 2.12 a second time..."
+    exit 1
+fi
+find . -name "pom.xml" -exec sed -e "s/2.11.12/2.12.6/g" \
+    -e "s/2.11/2.12/g" \
+    -i.2.12.bak '{}' \;
+
+find . -name "*.2.12.*bak" -exec rm -f {} \;

--- a/scripts/move_to_spark_2.sh
+++ b/scripts/move_to_spark_2.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set +x
-
-find . -name "pom.xml" -exec sed -e "/utils-/ s/_2.10/-spark2_2.10/g" \
-    -e "/spark.version/ s/1.6.3/2.1.0/g" \
-    -i .spark2.bak '{}' \;

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -20,64 +20,8 @@ echo "releasing from ${commit} on branch ${branch}"
 
 git push origin ${branch}
 
-# do scala 2.10 release
-git checkout -b maint_2.10-${release} ${branch}
-mvn --batch-mode \
-  -Dresume=false \
-  -Dtag=utils-parent_2.10-${release} \
-  -DreleaseVersion=${release} \
-  -DdevelopmentVersion=${devel} \
-  -DbranchName=utils_2.10-${release} \
-  release:clean \
-  release:prepare \
-  release:perform
-
-if [ $? != 0 ]; then
-  echo "Releasing Spark 1, Scala 2.10 version failed."
-  exit 1
-fi
-
-# do scala 2.11 release
-git checkout -b maint_2.11-${release} ${branch}
-./scripts/move_to_scala_2.11.sh
-git commit -a -m "Modifying pom.xml files for Spark 1, Scala 2.11 release."
-mvn --batch-mode \
-  -Dresume=false \
-  -Dtag=utils-parent_2.11-${release} \
-  -DreleaseVersion=${release} \
-  -DdevelopmentVersion=${devel} \
-  -DbranchName=utils_2.11-${release} \
-  release:clean \
-  release:prepare \
-  release:perform
-
-if [ $? != 0 ]; then
-  echo "Releasing Spark 1, Scala 2.11 version failed."
-  exit 1
-fi
-
-# do spark 2, scala 2.10 release
-git checkout -b maint_spark2_2.10-${release} ${branch}
-./scripts/move_to_spark_2.sh
-git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.10 release."
-mvn --batch-mode \
-  -Dresume=false \
-  -Dtag=utils-parent-spark2_2.10-${release} \
-  -DreleaseVersion=${release} \
-  -DdevelopmentVersion=${devel} \
-  -DbranchName=utils-spark2_2.10-${release} \
-  release:clean \
-  release:prepare \
-  release:perform
-
-if [ $? != 0 ]; then
-  echo "Releasing Spark 2, Scala 2.10 version failed."
-  exit 1
-fi
-
 # do spark 2, scala 2.11 release
 git checkout -b maint_spark2_2.11-${release} ${branch}
-./scripts/move_to_spark_2.sh
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.11 release."
 mvn --batch-mode \
@@ -92,6 +36,25 @@ mvn --batch-mode \
 
 if [ $? != 0 ]; then
   echo "Releasing Spark 2, Scala 2.11 version failed."
+  exit 1
+fi
+
+# do spark 2, scala 2.12 release
+git checkout -b maint_spark2_2.12-${release} ${branch}
+./scripts/move_to_scala_2.12.sh
+git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.12 release."
+mvn --batch-mode \
+  -Dresume=false \
+  -Dtag=utils-parent-spark2_2.12-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=utils-spark2_2.12-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing Spark 2, Scala 2.12 version failed."
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #124 

Scala 2.12 currently fails to build for me locally
```
$ ./scripts/move_to_scala_2.12.sh
$ mvn clean install
...
[INFO] ------------< org.bdgenomics.utils:utils-misc-spark2_2.12 >-------------
[INFO] Building utils-misc-spark2_2.12: Miscellaneous Spark helper code 0.2.14-SNAPSHOT [2/9]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ utils-misc-spark2_2.12 ---
[INFO] Deleting /working/bdg-utils/utils-misc/target
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-versions) @ utils-misc-spark2_2.12 ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-maven) @ utils-misc-spark2_2.12 ---
[INFO] 
[INFO] --- build-helper-maven-plugin:3.0.0:add-source (add-source) @ utils-misc-spark2_2.12 ---
[INFO] Source directory: /working/bdg-utils/utils-misc/src/main/scala added.
[INFO] 
[INFO] --- scalariform-maven-plugin:0.1.4:format (default-cli) @ utils-misc-spark2_2.12 ---
[INFO] Modified 0 of 7 .scala files
[INFO] 
[INFO] --- maven-resources-plugin:3.0.1:resources (default-resources) @ utils-misc-spark2_2.12 ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ utils-misc-spark2_2.12 ---
[INFO] /working/bdg-utils/utils-misc/src/main/scala:-1: info: compiling
[INFO] Compiling 3 source files to /working/bdg-utils/utils-misc/target/2.12.6/classes at 1543880345175
[INFO] prepare-compile in 0 s
[INFO] compile in 3 s
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ utils-misc-spark2_2.12 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- build-helper-maven-plugin:3.0.0:add-test-source (add-test-source) @ utils-misc-spark2_2.12 ---
[INFO] Test Source directory: /working/bdg-utils/utils-misc/src/test/scala added.
[INFO] 
[INFO] --- maven-resources-plugin:3.0.1:testResources (default-testResources) @ utils-misc-spark2_2.12 ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- scala-maven-plugin:3.2.2:testCompile (scala-test-compile-first) @ utils-misc-spark2_2.12 ---
[INFO] /working/bdg-utils/utils-misc/src/test/scala:-1: info: compiling
[INFO] Compiling 4 source files to /working/bdg-utils/utils-misc/target/2.12.6/test-classes at 1543880349787
[WARNING] warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:inline -opt-inline-from:**. Check -opt:help for using the Scala 2.12 optimizer.
[INFO] java.lang.ArrayIndexOutOfBoundsException: 15859
[INFO] 	at scala.tools.asm.ClassReader.readUTF(ClassReader.java:2624)
[INFO] 	at scala.tools.asm.ClassReader.readUTF8(ClassReader.java:2596)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.nextUTF8$1(InlineInfoAttribute.scala:95)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.$anonfun$read$1(InlineInfoAttribute.scala:116)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.$anonfun$read$1$adapted(InlineInfoAttribute.scala:114)
[INFO] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:234)
[INFO] 	at scala.collection.immutable.Range.foreach(Range.scala:156)
[INFO] 	at scala.collection.TraversableLike.map(TraversableLike.scala:234)
[INFO] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:227)
[INFO] 	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.read(InlineInfoAttribute.scala:114)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.read(InlineInfoAttribute.scala:33)
[INFO] 	at scala.tools.asm.ClassReader.readAttribute(ClassReader.java:2458)
[INFO] 	at scala.tools.asm.ClassReader.accept(ClassReader.java:610)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.$anonfun$parseClass$1(ByteCodeRepository.scala:259)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.parseClass(ByteCodeRepository.scala:250)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.$anonfun$parsedClassNode$1(ByteCodeRepository.scala:65)
[INFO] 	at scala.collection.mutable.MapLike.getOrElseUpdate(MapLike.scala:206)
[INFO] 	at scala.collection.mutable.MapLike.getOrElseUpdate$(MapLike.scala:203)
[INFO] 	at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:80)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.parsedClassNode(ByteCodeRepository.scala:65)
[INFO] 	at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.classNode(ByteCodeRepository.scala:86)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.buildInlineInfo(BTypesFromSymbols.scala:524)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.computeClassInfo(BTypesFromSymbols.scala:436)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.$anonfun$classBTypeFromSymbol$6(BTypesFromSymbols.scala:107)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypes$ClassBType$.apply(BTypes.scala:816)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.classBTypeFromSymbol(BTypesFromSymbols.scala:104)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.$anonfun$typeToBType$1(BTypesFromSymbols.scala:158)
[INFO] 	at scala.collection.MapLike.getOrElse(MapLike.scala:128)
[INFO] 	at scala.collection.MapLike.getOrElse$(MapLike.scala:126)
[INFO] 	at scala.collection.AbstractMap.getOrElse(Map.scala:59)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.primitiveOrClassToBType$1(BTypesFromSymbols.scala:158)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypesFromSymbols.typeToBType(BTypesFromSymbols.scala:173)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.symInfoTK(BCodeSkelBuilder.scala:78)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.makeLocal(BCodeSkelBuilder.scala:364)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.$anonfun$getOrMakeLocal$1(BCodeSkelBuilder.scala:369)
[INFO] 	at scala.collection.mutable.AnyRefMap.getOrElse(AnyRefMap.scala:130)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.getOrMakeLocal(BCodeSkelBuilder.scala:369)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:268)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genStat(BCodeBodyBuilder.scala:80)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genBlock(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:366)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.emitNormalMethodBody$1(BCodeSkelBuilder.scala:602)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genDefDef(BCodeSkelBuilder.scala:634)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:508)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.$anonfun$gen$7(BCodeSkelBuilder.scala:510)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:510)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genPlainClass(BCodeSkelBuilder.scala:110)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClass(CodeGen.scala:69)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDef$1(CodeGen.scala:31)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$3(CodeGen.scala:54)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:54)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$2(CodeGen.scala:53)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:53)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$4(CodeGen.scala:58)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genUnit(CodeGen.scala:58)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.apply(GenBCode.scala:67)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:426)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:419)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1(Global.scala:390)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1$adapted(Global.scala:390)
[INFO] 	at scala.collection.Iterator.foreach(Iterator.scala:944)
[INFO] 	at scala.collection.Iterator.foreach$(Iterator.scala:944)
[INFO] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1432)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:390)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.super$run(GenBCode.scala:73)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.$anonfun$run$1(GenBCode.scala:73)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.run(GenBCode.scala:71)
[INFO] 	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1446)
[INFO] 	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1430)
[INFO] 	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1423)
[INFO] 	at scala.tools.nsc.Global$Run.compile(Global.scala:1539)
[INFO] 	at scala.tools.nsc.Driver.doCompile(Driver.scala:35)
[INFO] 	at scala.tools.nsc.MainClass.doCompile(Main.scala:24)
[INFO] 	at scala.tools.nsc.Driver.process(Driver.scala:55)
[INFO] 	at scala.tools.nsc.Driver.main(Driver.scala:68)
[INFO] 	at scala.tools.nsc.Main.main(Main.scala)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[INFO] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.lang.reflect.Method.invoke(Method.java:498)
[INFO] 	at scala_maven_executions.MainHelper.runMain(MainHelper.java:164)
[INFO] 	at scala_maven_executions.MainWithArgsInFile.main(MainWithArgsInFile.java:26)
[ERROR] error: Error while emitting MathUtilsSuite.scala
[ERROR] 15859
[ERROR] java.lang.ArrayIndexOutOfBoundsException
[ERROR] error: Error while emitting SparkFunSuite.scala
[ERROR] null
[ERROR] java.lang.AssertionError: assertion failed: ClassBType.info not yet assigned: Lorg/apache/spark/rdd/RDD;
[INFO] 	at scala.tools.nsc.backend.jvm.BTypes$ClassBType.info(BTypes.scala:629)
[INFO] 	at scala.tools.nsc.backend.jvm.BTypes$ClassBType.isInterface(BTypes.scala:661)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genCallMethod(BCodeBodyBuilder.scala:1082)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:701)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:296)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:634)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:296)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1(BCodeBodyBuilder.scala:935)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadArguments(BCodeBodyBuilder.scala:935)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:665)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:296)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:270)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genStat(BCodeBodyBuilder.scala:80)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genBlock(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:366)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:270)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genStat(BCodeBodyBuilder.scala:80)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genBlock(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:366)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genStat(BCodeBodyBuilder.scala:80)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genBlock(BCodeBodyBuilder.scala:812)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:366)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.emitNormalMethodBody$1(BCodeSkelBuilder.scala:602)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genDefDef(BCodeSkelBuilder.scala:634)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:508)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.$anonfun$gen$7(BCodeSkelBuilder.scala:510)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:510)
[INFO] 	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genPlainClass(BCodeSkelBuilder.scala:110)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClass(CodeGen.scala:69)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDef$1(CodeGen.scala:31)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$3(CodeGen.scala:54)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:54)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$2(CodeGen.scala:53)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:53)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$4(CodeGen.scala:58)
[INFO] 	at scala.tools.nsc.backend.jvm.CodeGen.genUnit(CodeGen.scala:58)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.apply(GenBCode.scala:67)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:426)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:419)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1(Global.scala:390)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1$adapted(Global.scala:390)
[INFO] 	at scala.collection.Iterator.foreach(Iterator.scala:944)
[INFO] 	at scala.collection.Iterator.foreach$(Iterator.scala:944)
[INFO] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1432)
[INFO] 	at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:390)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.super$run(GenBCode.scala:73)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.$anonfun$run$1(GenBCode.scala:73)
[INFO] 	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.run(GenBCode.scala:71)
[INFO] 	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1446)
[INFO] 	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1430)
[INFO] 	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1423)
[INFO] 	at scala.tools.nsc.Global$Run.compile(Global.scala:1539)
[INFO] 	at scala.tools.nsc.Driver.doCompile(Driver.scala:35)
[INFO] 	at scala.tools.nsc.MainClass.doCompile(Main.scala:24)
[INFO] 	at scala.tools.nsc.Driver.process(Driver.scala:55)
[INFO] 	at scala.tools.nsc.Driver.main(Driver.scala:68)
[INFO] 	at scala.tools.nsc.Main.main(Main.scala)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[INFO] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.lang.reflect.Method.invoke(Method.java:498)
[INFO] 	at scala_maven_executions.MainHelper.runMain(MainHelper.java:164)
[INFO] 	at scala_maven_executions.MainWithArgsInFile.main(MainWithArgsInFile.java:26)
[ERROR] error: Error while emitting SparkFunSuiteSuite.scala
[ERROR] assertion failed: ClassBType.info not yet assigned: Lorg/apache/spark/rdd/RDD;
[WARNING] one warning found
[ERROR] three errors found
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for utils 0.2.14-SNAPSHOT:
[INFO] 
[INFO] utils .............................................. SUCCESS [  2.275 s]
[INFO] utils-misc-spark2_2.12: Miscellaneous Spark helper code FAILURE [ 11.144 s]
[INFO] utils-minhash-spark2_2.12: MinHash-based Jaccard similarity estimator SKIPPED
[INFO] utils-metrics-spark2_2.12: tools for collecting metrics on top of RDDs SKIPPED
[INFO] utils-io-spark2_2.12: I/O utils .................... SKIPPED
[INFO] utils-statistics-spark2_2.12: Spark code for fitting statistical models SKIPPED
[INFO] utils-cli-spark2_2.12: utilities for building command line applications SKIPPED
[INFO] utils-serialization-spark2_2.12: tools for serializing data SKIPPED
[INFO] utils-intervalrdd-spark2_2.12: IntervalRDD based on interval tree SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```