### PR TITLE
[UTILS-133] Update Spark dependency to 2.4.2, Parquet to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.version.prefix>2.11</scala.version.prefix>
     <spark.version>2.4.0</spark.version>
-    <parquet.version>1.8.3</parquet.version>
+    <parquet.version>1.10.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.5</hadoop.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
@@ -326,7 +326,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_2.11</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.7</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>1.8</java.version>
     <scala.version>2.11.12</scala.version>
     <scala.version.prefix>2.11</scala.version.prefix>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2.4.2</spark.version>
     <parquet.version>1.10.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.5</hadoop.version>


### PR DESCRIPTION
Fixes #133 

Updates Parquet dependency version to 1.10.1, which is newer than 1.10.0 included in Spark 2.4.2.

Does not include a fix for https://github.com/bigdatagenomics/adam/issues/2058 though.