### PR TITLE
[UTILS-153] Support Apache Spark 3.x in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,19 +293,19 @@
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-misc-spark2_2.11</artifactId>
+        <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-misc-spark2_2.11</artifactId>
+        <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>
-        <artifactId>utils-io-spark2_2.11</artifactId>
+        <artifactId>utils-io-spark2_${scala.version.prefix}</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -321,7 +321,7 @@
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>
-        <artifactId>scalatest_2.11</artifactId>
+        <artifactId>scalatest_${scala.version.prefix}</artifactId>
         <version>3.0.7</version>
         <scope>test</scope>
       </dependency>
@@ -364,13 +364,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-sql_2.11</artifactId>
+        <artifactId>spark-sql_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
 	<scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.11</artifactId>
+        <artifactId>spark-core_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
         <scope>provided</scope>
         <exclusions>
@@ -380,7 +380,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.twitter</groupId>
-            <artifactId>chill_2.11</artifactId>
+            <artifactId>chill_${scala.version.prefix}</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
@@ -390,7 +390,7 @@
       </dependency>
       <dependency>
         <groupId>org.scalanlp</groupId>
-        <artifactId>breeze_2.11</artifactId>
+        <artifactId>breeze_${scala.version.prefix}</artifactId>
         <version>0.13</version>
       </dependency>
       <dependency>
@@ -411,7 +411,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-mllib_2.11</artifactId>
+        <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
         <scope>provided</scope>
       </dependency>

--- a/scripts/move_to_spark_2.sh
+++ b/scripts/move_to_spark_2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set +x
+
+grep -q "spark2" pom.xml
+if [[ $? == 0 ]];
+then
+    echo "POM is already set up for Spark 2 (Spark 2 artifacts have -spark2 suffix in artifact names)."
+    echo "Cowardly refusing to move to Spark 2 a second time..."
+
+    exit 1
+fi
+
+svp="\${scala.version.prefix}"
+substitution_cmd="s/-spark3_$svp/-spark2_$svp/g"
+
+find . -name "pom.xml" -exec sed \
+    -e "/utils-/ s/-spark3_2\.1/-spark2_2\.1/" \
+    -e "/utils-/ $substitution_cmd" \
+    -e "/spark.version/ s/3.0.0-preview2/2.4.5/g" \
+    -i.spark2.bak '{}' \;

--- a/scripts/move_to_spark_3.sh
+++ b/scripts/move_to_spark_3.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set +x
+
+grep -q "spark3" pom.xml
+if [[ $? == 0 ]];
+then
+    echo "POM is already set up for Spark 3 (Spark 3 artifacts have -spark3 suffix in artifact names)."
+    echo "Cowardly refusing to move to Spark 3 a second time..."
+
+    exit 1
+fi
+
+svp="\${scala.version.prefix}"
+substitution_cmd="s/-spark2_$svp/-spark3_$svp/g"
+
+find . -name "pom.xml" -exec sed \
+    -e "/utils-/ s/-spark2_2\.1/-spark3_2\.1/" \
+    -e "/utils-/ $substitution_cmd" \
+    -e "/spark.version/ s/2.4.5/3.0.0-preview2/g" \
+    -i.spark3.bak '{}' \;

--- a/utils-cli/pom.xml
+++ b/utils-cli/pom.xml
@@ -70,11 +70,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/utils-intervalrdd/pom.xml
+++ b/utils-intervalrdd/pom.xml
@@ -89,25 +89,25 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/utils-io/pom.xml
+++ b/utils-io/pom.xml
@@ -90,11 +90,11 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
@@ -108,11 +108,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/utils-minhash/pom.xml
+++ b/utils-minhash/pom.xml
@@ -90,13 +90,13 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
@@ -108,16 +108,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.11</artifactId>
+      <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/utils-misc/pom.xml
+++ b/utils-misc/pom.xml
@@ -98,16 +98,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/utils-serialization/pom.xml
+++ b/utils-serialization/pom.xml
@@ -90,7 +90,7 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -114,7 +114,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -123,7 +123,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.twitter</groupId>
-          <artifactId>chill_2.11</artifactId>
+          <artifactId>chill_${scala.version.prefix}</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/utils-statistics/pom.xml
+++ b/utils-statistics/pom.xml
@@ -102,21 +102,21 @@
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
-      <artifactId>utils-misc-spark2_2.11</artifactId>
+      <artifactId>utils-misc-spark2_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.11</artifactId>
+      <artifactId>spark-mllib_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -124,12 +124,12 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_${scala.version.prefix}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalanlp</groupId>
-      <artifactId>breeze_2.11</artifactId>
+      <artifactId>breeze_${scala.version.prefix}</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Fixes #153 

```
$ ./scripts/move_to_scala_2.12.sh
$ ./scripts/move_to_spark_3.sh
$ mvn clean install
...
[INFO] --- scala-maven-plugin:3.2.2:compile (scala-compile-first) @ utils-metrics-spark3_2.12 ---
[INFO] /working/bdg-utils/utils-metrics/src/main/scala:-1: info: compiling
[INFO] Compiling 22 source files to /working/bdg-utils/utils-metrics/target/2.12.8/classes at 1581361965894
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/Metrics.scala:26: error: object Accumulable is not a member of package org.apache.spark
[ERROR] import org.apache.spark.{ Accumulable, SparkContext }
[ERROR]        ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/ServoTimersAccumulableParam.scala:21: error: object AccumulableParam is not a member of package org.apache.spark
[ERROR] import org.apache.spark.AccumulableParam
[ERROR]        ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/ServoTimersAccumulableParam.scala:28: error: not found: type AccumulableParam
[ERROR] class ServoTimersAccumulableParam extends AccumulableParam[ServoTimers, RecordedTiming] {
[ERROR]                                           ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/Metrics.scala:103: error: value accumulable is not a member of org.apache.spark.SparkContext
[ERROR]     val accumulable = sparkContext.accumulable[ServoTimers, RecordedTiming](new ServoTimers())
[ERROR]                                    ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/MetricsRecorder.scala:20: error: object Accumulable is not a member of package org.apache.spark
[ERROR] import org.apache.spark.Accumulable
[ERROR]        ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/MetricsRecorder.scala:32: error: not found: type Accumulable
[ERROR] class MetricsRecorder(val accumulable: Accumulable[ServoTimers, RecordedTiming],
[ERROR]                                        ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/Metrics.scala:156: error: not found: type Accumulable
[ERROR]                                  accumulable: Accumulable[ServoTimers, RecordedTiming]) {
[ERROR]                                               ^
[ERROR] /working/bdg-utils/utils-metrics/src/main/scala/org/bdgenomics/utils/instrumentation/Metrics.scala:218: error: not found: type Accumulable
[ERROR]   private def buildTree(accumulable: Accumulable[ServoTimers, RecordedTiming]): Iterable[TreeNode] = {
[ERROR]                                      ^
[ERROR] 8 errors found
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for utils-metrics-spark3_2.12: tools for collecting metrics on top of RDDs 0.2.16-SNAPSHOT:
[INFO] 
[INFO] utils-metrics-spark3_2.12: tools for collecting metrics on top of RDDs FAILURE [  9.983 s]

```